### PR TITLE
Add generic chunker library and simple API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# ai-datachunker
+# AI Data Chunker
+
+This repository provides a small utility to split arbitrary data into chunks. It
+exposes a reusable library and a lightweight API server implemented with the
+standard library.
+
+## Library Usage
+
+```python
+from datachunker import DataChunker, ChunkConfig
+
+config = ChunkConfig(chunk_size=100, overlap=10, mode="word")
+chunker = DataChunker(config)
+
+chunks = chunker.chunk("some long text ...")
+```
+
+## API Usage
+
+Run the HTTP server:
+
+```bash
+python server.py
+```
+
+Then send a POST request to `/chunk` with the data and configuration:
+
+```bash
+curl -X POST http://localhost:8000/chunk \
+  -H "Content-Type: application/json" \
+  -d '{"data": "your text", "chunk_size": 100, "overlap": 10, "mode": "word"}'
+```
+
+## Development
+
+Install dependencies and run tests with `pytest`.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+from typing import List, Union
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from datachunker import ChunkConfig, DataChunker
+
+app = FastAPI(title="Generic Data Chunker")
+
+
+class ChunkRequest(BaseModel):
+    data: Union[str, List[str]]
+    chunk_size: int = 100
+    overlap: int = 0
+    mode: str = "word"
+
+
+@app.post("/chunk")
+async def chunk_data(request: ChunkRequest):
+    config = ChunkConfig(
+        chunk_size=request.chunk_size,
+        overlap=request.overlap,
+        mode=request.mode,
+    )
+    chunker = DataChunker(config)
+    chunks = chunker.chunk(request.data)
+    return {"chunks": chunks}

--- a/datachunker/__init__.py
+++ b/datachunker/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable library for chunking data."""
+
+from .config import ChunkConfig
+from .chunker import DataChunker
+
+__all__ = ["ChunkConfig", "DataChunker"]

--- a/datachunker/chunker.py
+++ b/datachunker/chunker.py
@@ -1,0 +1,36 @@
+from typing import List, Sequence, Union
+
+from .config import ChunkConfig
+
+
+class DataChunker:
+    """Generic utility to split data into chunks."""
+
+    def __init__(self, config: ChunkConfig) -> None:
+        self.config = config
+
+    def chunk(self, data: Union[str, Sequence[str]]) -> List[str]:
+        """Chunk the input data according to the configuration."""
+        if isinstance(data, str):
+            text = data
+        else:
+            text = " ".join(str(d) for d in data)
+
+        if self.config.mode == "word":
+            tokens = text.split()
+            joiner = " ".join
+        else:
+            tokens = list(text)
+            joiner = "".join
+
+        chunk_size = self.config.chunk_size
+        step = chunk_size - self.config.overlap
+        chunks: List[str] = []
+        i = 0
+        while i < len(tokens):
+            chunk = joiner(tokens[i : i + chunk_size])
+            chunks.append(chunk)
+            if i + chunk_size >= len(tokens):
+                break
+            i += step
+        return chunks

--- a/datachunker/config.py
+++ b/datachunker/config.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ChunkConfig:
+    """Configuration for data chunking."""
+
+    chunk_size: int = 100
+    overlap: int = 0
+    mode: str = "word"
+
+    def __post_init__(self) -> None:
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be greater than 0")
+        if self.overlap < 0 or self.overlap >= self.chunk_size:
+            raise ValueError("overlap must be non-negative and less than chunk_size")
+        if self.mode not in {"word", "char"}:
+            raise ValueError("mode must be 'word' or 'char'")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.111.0
+uvicorn>=0.29.0
+pydantic>=2.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,45 @@
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from datachunker import ChunkConfig, DataChunker
+
+
+class ChunkHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        if self.path != "/chunk":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Invalid JSON")
+            return
+
+        config = ChunkConfig(
+            chunk_size=payload.get("chunk_size", 100),
+            overlap=payload.get("overlap", 0),
+            mode=payload.get("mode", "word"),
+        )
+        chunker = DataChunker(config)
+        chunks = chunker.chunk(payload.get("data", ""))
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"chunks": chunks}).encode())
+
+
+def run(host: str = "0.0.0.0", port: int = 8000) -> None:
+    server = HTTPServer((host, port), ChunkHandler)
+    print(f"Serving on {host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from datachunker import DataChunker, ChunkConfig
+
+
+def test_chunk_by_word():
+    config = ChunkConfig(chunk_size=3, overlap=1, mode="word")
+    chunker = DataChunker(config)
+    text = "one two three four five six"
+    assert chunker.chunk(text) == [
+        "one two three",
+        "three four five",
+        "five six",
+    ]
+
+
+def test_chunk_by_char():
+    config = ChunkConfig(chunk_size=4, overlap=2, mode="char")
+    chunker = DataChunker(config)
+    text = "abcdefg"
+    assert chunker.chunk(text) == ["abcd", "cdef", "efg"]


### PR DESCRIPTION
## Summary
- implement `ChunkConfig` dataclass and `DataChunker` class
- add lightweight HTTP API server using the standard library
- create tests for the chunking logic
- update README with usage instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685104173454832e9e02a5d63b485f05